### PR TITLE
recover from long-path error, add progress bar, rearrange some logic.

### DIFF
--- a/CMH-PP.py
+++ b/CMH-PP.py
@@ -40,7 +40,12 @@ def display_welcome_message():
         "Welcome to the CMH Playset Preserver for Crusader Kings 3"
         "\nGitHub repository: https://github.com/Ant0nidas/CMH-Playset-Preserver"
         "\nJoin CMH on Discord: https://discord.gg/GuDjt9YQ"
-        "\nPlease answer the prompts to continue:"
+        "\n"
+        "\nAnswer the following prompts by typing a response and then pressing Enter."
+        "\nWhen a prompt has a default answer, it will appear between brackets."
+        "\nPress Enter with an empty response to accept that default."
+        "\n"
+        "\nTo exit the program at any time, press Ctrl+C."
     )
 
 
@@ -262,7 +267,7 @@ def main():
         "By using this method, you agree to not seek advice for gameplay or mod-related issues,"
         "\nbe it on the authors discord servers, steam pages, or elsewhere."
         "\nNo support or troubleshooting can be given."
-        "\nHave you understood? - y/n: "
+        "\nHave you understood? - y/[n]: "
     )
     if agreement.lower() != "y":
         print()

--- a/CMH-PP.py
+++ b/CMH-PP.py
@@ -134,7 +134,7 @@ def copy_mod_folders(mods, destination_path):
                 ignore=shutil.ignore_patterns(".git"),
                 dirs_exist_ok=True,
             )
-            print(f"Copied contents of {mod["displayName"]}")
+            print(f"Copied contents of {mod['displayName']}")
         else:
             print(f"{mod['displayName']} not found.")
             not_found_mods.append(mod["displayName"])
@@ -150,12 +150,13 @@ def clean_combined_folder(destination_path):
 
 
 def create_descriptor_file(destination_path, mod_name, game_version):
+    escaped_name = mod_name.replace('"', '\\"')
     descriptor_content = dedent(f"""\
         version="1.0"
         tags={{
             "Utilities"
         }}
-        name="{mod_name.replace('"', '\\"')}"
+        name="{escaped_name}"
         supported_version="{game_version}.*"
         """)
     descriptor_path = destination_path / "descriptor.mod"
@@ -165,12 +166,13 @@ def create_descriptor_file(destination_path, mod_name, game_version):
 
 
 def create_mod_file(mod_directory, mod_folder_name, mod_name, game_version):
+    escaped_name = mod_name.replace('"', '\\"')
     mod_file_content = dedent(f"""\
         version="1.0"
         tags={{
             "Utilities"
         }}
-        name="{mod_name.replace('"', '\\"')}"
+        name="{escaped_name}"
         supported_version="{game_version}.*"
         path="mod/{mod_folder_name}"
         """)
@@ -212,7 +214,8 @@ def get_new_mod_name(playset_name):
     # E.g. "My Playset (2024-05-06)"
     date = datetime.date.today().isoformat()
     # .mod files can't handle backslashes in names, except for \"
-    new_mod_name = f"{playset_name.replace("\\", "")} ({date})"
+    cleaned_name = playset_name.replace("\\", "")
+    new_mod_name = f"{cleaned_name} ({date})"
 
     new_mod_name_input = input(f"Enter preserved playset name [{new_mod_name}]: ")
     new_mod_name = new_mod_name_input or new_mod_name


### PR DESCRIPTION
- (55a575f) fix foolish syntax errors in #2 
- upon windows error from too long path, prompt user for a shorter folder name, and retry (#3 no. 29)
  - (new issue) currently it will error if the new new folder name already exists. this behavior needs to be consistent with what it does with the original new folder name
- add progress bar based on number of directories copied (#3 no. 26)
  - (+ tqdm dependency, should work fine with pyinstaller with no changes)
- stop prompting to include disabled mods, just inform the user they aren't included
- check for backslash in user name input and re-prompt (#3 no. 24)
- (3385ccc) explained default inputs in brackets in welcome message  (#3 no. 30)
- removed warning about launcher data corruption (#3 no. 19)
  - it's not any riskier than writing to `mods/` directory, certainly as the script is now where it'll silently overwrite existing folder
- check not-found mods before copying, and give user option to exit early based on it
- rearrange the order of some operations
- add some more line breaks for clearer output